### PR TITLE
Populate Course Meetings is an independent step

### DIFF
--- a/PopulateDatamartStaging_V2/PopulateCourses.dtsx
+++ b/PopulateDatamartStaging_V2/PopulateCourses.dtsx
@@ -7,12 +7,12 @@
   DTS:CreatorName="ACADEMIC\webserv"
   DTS:DTSID="{EAA3039E-CA19-4091-91F5-AF5268A5F174}"
   DTS:ExecutableType="SSIS.Package.3"
-  DTS:LastModifiedProductVersion="11.0.5058.0"
+  DTS:LastModifiedProductVersion="15.0.0900.30"
   DTS:LocaleID="1033"
   DTS:ObjectName="PopulateCourses"
   DTS:PackageType="5"
-  DTS:VersionBuild="6"
-  DTS:VersionGUID="{446A720C-07EF-4FD3-8BF2-C3C71838A937}">
+  DTS:VersionBuild="7"
+  DTS:VersionGUID="{F099597B-CAC2-45E8-B4BE-C8A0FA8B017B}">
   <DTS:Property
     DTS:Name="PackageFormatVersion">6</DTS:Property>
   <DTS:ConnectionManagers>
@@ -63,6 +63,7 @@
       DTS:refId="Package\Populate Courses Meeting"
       DTS:CreationName="SSIS.ExecutePackageTask.3"
       DTS:Description="Execute Package Task"
+      DTS:Disabled="True"
       DTS:DTSID="{721869E6-AD4D-4230-A832-6D4F21F3E63A}"
       DTS:ExecutableType="SSIS.ExecutePackageTask.3"
       DTS:LocaleID="-1"
@@ -161,11 +162,11 @@
     design-time-name="Package">
     <LayoutInfo>
       <GraphLayout
-        Capacity="8" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml">
+        Capacity="8" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
         <NodeLayout
           Size="185,42"
           Id="Package\Populate Courses Meeting"
-          TopLeft="242,294" />
+          TopLeft="241,294" />
         <NodeLayout
           Size="243,48"
           Id="Package\PopulateCourses_Comments"
@@ -183,7 +184,7 @@
           TopLeft="278.5,110">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{assembly:Null}"
+              StartConnector="{x:Null}"
               EndConnector="-139.5,82"
               Start="0,0"
               End="-139.5,74.5">
@@ -217,10 +218,10 @@
           TopLeft="323,110">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{assembly:Null}"
-              EndConnector="11.5,184"
+              StartConnector="{x:Null}"
+              EndConnector="10.5,184"
               Start="0,0"
-              End="11.5,176.5">
+              End="10.5,176.5">
               <mssgle:Curve.Segments>
                 <mssgle:SegmentCollection
                   Capacity="5">
@@ -231,13 +232,13 @@
                     Point2="0,92"
                     Point3="4,92" />
                   <mssgle:LineSegment
-                    End="7.5,92" />
+                    End="6.5,92" />
                   <mssgle:CubicBezierSegment
-                    Point1="7.5,92"
-                    Point2="11.5,92"
-                    Point3="11.5,96" />
+                    Point1="6.5,92"
+                    Point2="10.5,92"
+                    Point3="10.5,96" />
                   <mssgle:LineSegment
-                    End="11.5,176.5" />
+                    End="10.5,176.5" />
                 </mssgle:SegmentCollection>
               </mssgle:Curve.Segments>
             </mssgle:Curve>
@@ -251,7 +252,7 @@
           TopLeft="367.5,110">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{assembly:Null}"
+              StartConnector="{x:Null}"
               EndConnector="197,140"
               Start="0,0"
               End="197,132.5">

--- a/PopulateDatamartStaging_V2/PopulateCourses_Meeting.dtsx
+++ b/PopulateDatamartStaging_V2/PopulateCourses_Meeting.dtsx
@@ -11,8 +11,8 @@
   DTS:LocaleID="1033"
   DTS:ObjectName="PopulateCourses_Meeting"
   DTS:PackageType="5"
-  DTS:VersionBuild="26"
-  DTS:VersionGUID="{EB921C35-B4DA-475D-8D18-9617FEE02344}">
+  DTS:VersionBuild="27"
+  DTS:VersionGUID="{20E0812D-2AFD-4482-A774-68BC07BB93AC}">
   <DTS:Property
     DTS:Name="PackageFormatVersion">6</DTS:Property>
   <DTS:ConnectionManagers>
@@ -23,11 +23,11 @@
       DTS:ObjectName="HERMES.staging">
       <DTS:ObjectData>
         <DTS:ConnectionManager
-          DTS:ConnectionString="Data Source=HERMES;User ID=integration_user;Initial Catalog=Staging;Provider=SQLNCLI11.1;Persist Security Info=True;Auto Translate=False;">
+          DTS:ConnectionString="Data Source=HERMES;User ID=NewDataWriter;Initial Catalog=Staging;Provider=SQLNCLI11.1;Persist Security Info=True;Auto Translate=False;">
           <DTS:Password
             DTS:Name="Password"
             Sensitive="1"
-            Encrypted="1">AQAAANCMnd8BFdERjHoAwE/Cl+sBAAAAH2cHOOrgB0eEQpI3VpLmuwAAAAAIAAAARABUAFMAAAADZgAAwAAAABAAAAB9UQDicmbuhvbdc6z/mHmCAAAAAASAAACgAAAAEAAAAA+h4URUVagpEhvJ90yfxT1YAAAAZRVimQN1Gyq8Cyhz7Jdy/3QVOCw3jsW8CoIAgJOa8ejDMBpRwiz2paoIiYdhzaqwkgF6dXOVAUfm9u7+qNRXvUCE+CEt0gJoCJur26Em44sBMNRhsycr5BQAAAAjhuslONyZ33e8CvGXdoNgLgF2tw</DTS:Password>
+            Encrypted="1">AQAAANCMnd8BFdERjHoAwE/Cl+sBAAAAtIWotzDxqUC7DpeGBzJj2gAAAAAIAAAARABUAFMAAAADZgAAwAAAABAAAAD8hD5lihPuJNCBgBUWkvS/AAAAAASAAACgAAAAEAAAAATykJFH76UTH42oXNqmbccwAAAAVD5ePC7Z7VTzq8r1nOF33duNC4W41lOjHv2Xi7n7skNz5XxpcSsZ6OdAa//2vyI/FAAAAL0ZNbr/reoEQdO7vQ6hZGuMRNh4</DTS:Password>
         </DTS:ConnectionManager>
       </DTS:ObjectData>
     </DTS:ConnectionManager>
@@ -112,7 +112,7 @@
       DTS:LocaleID="-1"
       DTS:ObjectName="Populate DM_COURSES_MEETINGS"
       DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2012; © 2007 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
-      DTS:ThreadHint="3">
+      DTS:ThreadHint="2">
       <DTS:Variables />
       <DTS:ObjectData>
         <SQLTask:SqlTaskData
@@ -149,7 +149,7 @@
       DTS:LocaleID="-1"
       DTS:ObjectName="Task Clear Datamart staging table DM_COURSES_MEETING has failed"
       DTS:TaskContact="Send Mail Task; Microsoft Corporation; SQL Server 2012; © 2007 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
-      DTS:ThreadHint="2">
+      DTS:ThreadHint="3">
       <DTS:Variables />
       <DTS:ObjectData>
         <SendMailTask:SendMailTaskData
@@ -171,7 +171,7 @@
       DTS:LocaleID="-1"
       DTS:ObjectName="Task Populate Datamart staging table DM_COURSES_MEETING has failed"
       DTS:TaskContact="Send Mail Task; Microsoft Corporation; SQL Server 2012; © 2007 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
-      DTS:ThreadHint="3">
+      DTS:ThreadHint="2">
       <DTS:Variables />
       <DTS:ObjectData>
         <SendMailTask:SendMailTaskData
@@ -249,7 +249,7 @@
     design-time-name="Package">
     <LayoutInfo>
       <GraphLayout
-        Capacity="16" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph" xmlns:mssge="clr-namespace:Microsoft.SqlServer.Graph.Extended;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:av="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+        Capacity="16" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph" xmlns:mssge="clr-namespace:Microsoft.SqlServer.Graph.Extended;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:av="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
         <NodeLayout
           Size="257,42"
           Id="Package\Clear course_meeting_times_by_days"
@@ -283,7 +283,7 @@
           TopLeft="173,92">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{x:Null}"
+              StartConnector="{assembly:Null}"
               EndConnector="95,104"
               Start="0,0"
               End="95,96.5">
@@ -317,7 +317,7 @@
           TopLeft="289,71">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{x:Null}"
+              StartConnector="{assembly:Null}"
               EndConnector="86,53"
               Start="0,0"
               End="78.5,53">
@@ -353,7 +353,7 @@
           TopLeft="268,238">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{x:Null}"
+              StartConnector="{assembly:Null}"
               EndConnector="340.5,63"
               Start="0,0"
               End="340.5,55.5">
@@ -389,7 +389,7 @@
           TopLeft="1276,151">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{x:Null}"
+              StartConnector="{assembly:Null}"
               EndConnector="0,118"
               Start="0,0"
               End="0,110.5">
@@ -411,7 +411,7 @@
           TopLeft="1403,130">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{x:Null}"
+              StartConnector="{assembly:Null}"
               EndConnector="235,47"
               Start="0,0"
               End="227.5,47">
@@ -447,7 +447,7 @@
           TopLeft="1321.66666666667,269">
           <EdgeLayout.Curve>
             <mssgle:Curve
-              StartConnector="{x:Null}"
+              StartConnector="{assembly:Null}"
               EndConnector="391.333333333333,-71"
               Start="0,0"
               End="391.333333333333,-63.5">


### PR DESCRIPTION
Populate course meetings has it's own step in the sequence in ODS.  We don't need a file pointer to run it an extra time.  Disable the file pointer.